### PR TITLE
Modify file element color

### DIFF
--- a/src/components/FileElement.tsx
+++ b/src/components/FileElement.tsx
@@ -27,7 +27,7 @@ const Widget = styled('div')(({ theme }) => ({
   //   backgroundColor:
   //     theme.palette.mode === 'dark' ? 'rgba(0,0,0,0.6)' : 'rgba(255,255,255,0.4)',
   backdropFilter: 'blur(40px)',
-  background: 'skyblue',
+  background: '#03a9f4',
   transition: '0.2s all',
   '&:hover': {
     opacity: 0.75


### PR DESCRIPTION
This changes the background color of the "attached file" element to allow for better readability.  Currently the color used (skyblue) can be hard to read with white text in dark mode.  The color used for other elements (deepskyblue) was also tested, but the "Qortal blue" (#03a9f4) was chosen, as it provides more improvement.  This has been published to QDN at `qortal://app/QM-Blog` to facilitate testing.